### PR TITLE
Typed Node_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,55 @@
 # npm_rs
 
-A library to run npm commands from your Rust build script.
+A library to run `npm` commands from your Rust build script.
 
 [Documentation](https://docs.rs/npm_rs)
 
-This library will aid you in executing **npm** commands when building your crate/bin,
+This library will aid you in executing `npm` commands when building your crate/bin,
 removing the burden on having to manually do so or by using a tool other than **Cargo**.
 
-## Using npm_rs
+<!-- cargo-sync-readme start -->
+
+This crate provides an abstraction over [`Command`] to use `npm`
+in a simple and easy package with fluent API.
+
+`npm_rs` exposes [`NpmEnv`] to configure the `npm` execution enviroment and
+[`Npm`] to use said enviroment to execute `npm` commands.
+
+# Examples
+## Manual `NODE_ENV` setup
 ```rust
 // build.rs
 
-fn main() -> Result<(), Box<dyn std::error:Error>>{
-    npm_rs::NpmEnv::default()
-                   .with_env("NODE_ENV", "production")
-                   .init_env()
-                   .install(None)
-                   .run("build")
-                   .exec()?;
+use npm_rs::*;
 
-    Ok(())
-}
+let exit_status = NpmEnv::default()
+       .with_node_env(&NodeEnv::Production)
+       .with_env("FOO", "bar")
+       .init_env()
+       .install(None)
+       .run("build")
+       .exec()?;
 ```
+
+## Automatic `NODE_ENV` setup
+```rust
+// build.rs
+
+use npm_rs::*;
+
+let exit_status = NpmEnv::default()
+       .with_node_env(&NodeEnv::from_cargo_profile().unwrap_or_default())
+       .with_env("FOO", "bar")
+       .init_env()
+       .install(None)
+       .run("build")
+       .exec()?;
+```
+
+[`NpmEnv`] implements [`Clone`] while under a nightly toolchain
+when feature `nightly` is enabled.
+
+<!-- cargo-sync-readme end -->
 
 ## Features
 `NpmEnv` can be `Clone` when the feature `nightly` is enabled. This only works under a nightly toolchain.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # npm_rs
 
+![License (MIT OR APACHE)](https://img.shields.io/crates/l/npm_rs?style=flat-square)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/upsettingboy/npm_rs/Rust?style=flat-square&logo=github&label=CI)](https://github.com/upsettingboy/npm_rs/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/npm_rs?style=flat-square)](https://crates.io/crates/npm_rs)
+[![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=webpage&color=brightgreen&style=flat-square)](https://docs.rs/npm_rs)
+
 A library to run `npm` commands from your Rust build script.
 
 [Documentation](https://docs.rs/npm_rs)
@@ -51,7 +56,7 @@ when feature `nightly` is enabled.
 
 <!-- cargo-sync-readme end -->
 
-## Features
+# Features
 `NpmEnv` can be `Clone` when the feature `nightly` is enabled. This only works under a nightly toolchain.
 ```toml
 # Cargo.toml
@@ -60,10 +65,10 @@ when feature `nightly` is enabled.
 npm_rs = { version = "*", features = ["nightly"] }
 ```
 
-## Stability
+# Stability
 Since this is a small library, I would like it to have all the needed features and to be usable before commiting to a **v1.0.0**.
 
 Contributions are welcome!
 
-## License
+# License
 `npm_rs` is either distributed under **MIT** or **Apache-2.0** license. Choose as you please.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! # Examples
 //! ## Manual `NODE_ENV` setup
 //! ```no_run
+//! // build.rs
+//!
 //! use npm_rs::*;
 //!
 //! let exit_status = NpmEnv::default()
@@ -21,6 +23,8 @@
 //!
 //! ## Automatic `NODE_ENV` setup
 //! ```no_run
+//! // build.rs
+//!
 //! use npm_rs::*;
 //!
 //! let exit_status = NpmEnv::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,17 @@
-//! This crate provides an abstraction over [`Command`] with manual `npm` commands
+//! This crate provides an abstraction over [`Command`] to use `npm`
 //! in a simple and easy package with fluent API.
 //!
-//! `npm_rs` exposes [NpmEnv] to configure the npm execution enviroment and
-//! [Npm] to use said enviroment to execute npm commands.
+//! `npm_rs` exposes [`NpmEnv`] to configure the `npm` execution enviroment and
+//! [`Npm`] to use said enviroment to execute `npm` commands.
 //!
-//! # Example
+//! # Examples
+//! ## Manual `NODE_ENV` setup
 //! ```no_run
 //! use npm_rs::*;
 //!
 //! let exit_status = NpmEnv::default()
-//!        .with_env("NODE_ENV", "production")
+//!        .with_node_env(&NodeEnv::Production)
+//!        .with_env("FOO", "bar")
 //!        .init_env()
 //!        .install(None)
 //!        .run("build")
@@ -17,7 +19,21 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
-//! [NpmEnv] implements [`Clone`] while under a nightly toolchain
+//! ## Automatic `NODE_ENV` setup
+//! ```no_run
+//! use npm_rs::*;
+//!
+//! let exit_status = NpmEnv::default()
+//!        .with_node_env(&NodeEnv::from_cargo_profile().unwrap_or_default())
+//!        .with_env("FOO", "bar")
+//!        .init_env()
+//!        .install(None)
+//!        .run("build")
+//!        .exec()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! [`NpmEnv`] implements [`Clone`] while under a nightly toolchain
 //! when feature `nightly` is enabled.
 
 #![cfg_attr(feature = "nightly", feature(command_access))]
@@ -48,6 +64,9 @@ const NPM_UNINSTALL: &str = "uninstall";
 const NPM_UPDATE: &str = "update";
 const NPM_RUN: &str = "run";
 
+/// This enum is used to determine the desired `NODE_ENV` variable value. Its value by [`Default`] is [`NodeEnv::Development`]
+///
+/// Can be retrieved from Cargo env var `PROFILE` using [`NodeEnv::from_cargo()`](NodeEnv::from_cargo) or created manually.
 pub enum NodeEnv {
     Development,
     Production,
@@ -55,15 +74,16 @@ pub enum NodeEnv {
 }
 
 /// This struct is used to create the enviroment in which npm will execute commands.
-/// `NpmEnv` uses [`Command`] so it takes all the env variables in your system.
+/// [`NpmEnv`] uses [`Command`] so it takes all the env variables in your system.
 ///
-/// After the environment is configured, use [`NpmEnv::init()`] to start issuing commands to [`Npm`].
+/// After the environment is configured, use [`NpmEnv::init_env()`](NpmEnv::init_env) to start issuing commands to [`Npm`].
 /// # Example
 /// ```no_run
 /// use npm_rs::*;
 ///
 /// let npm = NpmEnv::default()
-///                  .with_env("NODE_ENV", "production")
+///                  .with_node_env(&NodeEnv::Production)
+///                  .with_env("FOO", "bar")
 ///                  .init_env();
 /// ```
 pub struct NpmEnv(Command);
@@ -91,7 +111,13 @@ impl Default for NodeEnv {
 }
 
 impl NodeEnv {
-    pub fn from_cargo() -> Result<Self, std::env::VarError> {
+    /// Creates a [`NodeEnv`] enum from the Cargo `PROFILE` enviroment variable as follows:
+    /// - If `PROFILE` = `debug` then [`NodeEnv::Development`].
+    /// - If `PROFILE` = `release` then [`NodeEnv::Production`].
+    /// - Else [`NodeEnv::Custom(String)`] with the value of `PROFILE`.
+    ///
+    /// This function is roughly equivalent to `NpmEnv::with_env("NODE_ENV", PROFILE)`.
+    pub fn from_cargo_profile() -> Result<Self, std::env::VarError> {
         Ok(match &std::env::var("PROFILE")?[..] {
             "debug" => Self::Development,
             "release" => Self::Production,
@@ -122,6 +148,7 @@ impl Clone for NpmEnv {
 }
 
 impl NpmEnv {
+    /// Inserts or updates the `NODE_ENV` envoriment variable.
     pub fn with_node_env(self, node_env: &NodeEnv) -> Self {
         let env = match node_env {
             NodeEnv::Development => "development",


### PR DESCRIPTION
Creation of an enum to type-check the env var NODE_ENV. This work also allows to get this value from the PROFILE env var that Cargo sets in build scripts.